### PR TITLE
✨ Add --skip-rows option to skip initial rows in CSV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ csvnorm input.csv [options]
 | `-f, --force` | Force overwrite of existing output file (when `-o` is specified) |
 | `-k, --keep-names` | Keep original column names (disable snake_case) |
 | `-d, --delimiter CHAR` | Set custom output delimiter (default: `,`) |
+| `-s, --skip-rows N` | Skip first N rows of input file (useful for metadata/comments) |
 | `--fix-mojibake [N]` | Fix mojibake using ftfy (optional sample size `N`) |
 | `-V, --verbose` | Enable verbose output for debugging |
 | `-v, --version` | Show version number |
@@ -109,6 +110,9 @@ csvnorm data.csv -d ';' -o output.csv
 
 # Keep original headers
 csvnorm data.csv --keep-names -o output.csv
+
+# Skip first 2 rows (metadata or comments)
+csvnorm data.csv --skip-rows 2 -o output.csv
 
 # Force overwrite with verbose output
 csvnorm data.csv -f -V -o processed.csv

--- a/src/csvnorm/cli.py
+++ b/src/csvnorm/cli.py
@@ -56,6 +56,7 @@ Examples:
   csvnorm data.csv > output.csv             # Shell redirect
   csvnorm data.csv | head -20               # Preview with pipe
   csvnorm data.csv -d ';' -o output.csv     # Custom delimiter
+  csvnorm data.csv --skip-rows 2 -o out.csv # Skip first 2 rows
   csvnorm https://example.com/data.csv -o processed.csv
 """,
     )
@@ -89,6 +90,17 @@ Examples:
         "--delimiter",
         default=",",
         help="Set custom field delimiter (default: comma). Example: -d ';'",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--skip-rows",
+        type=int,
+        default=0,
+        help=(
+            "Skip first N rows of input file. Useful for CSV files with "
+            "metadata or comments before the header row. Example: --skip-rows 2"
+        ),
     )
 
     parser.add_argument(
@@ -155,6 +167,11 @@ def main(argv: Optional[list[str]] = None) -> int:
     # Setup logging
     setup_logger(args.verbose)
 
+    # Validate skip_rows
+    if args.skip_rows < 0:
+        console.print("[red]Error:[/red] --skip-rows must be non-negative", style="red")
+        return 1
+
     # Run processing (output_file can be None for stdout)
     fix_mojibake_sample = args.fix_mojibake
     return process_csv(
@@ -163,6 +180,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         force=args.force,
         keep_names=args.keep_names,
         delimiter=args.delimiter,
+        skip_rows=args.skip_rows,
         verbose=args.verbose,
         fix_mojibake_sample=fix_mojibake_sample,
     )

--- a/src/csvnorm/core.py
+++ b/src/csvnorm/core.py
@@ -37,6 +37,7 @@ def process_csv(
     force: bool = False,
     keep_names: bool = False,
     delimiter: str = ",",
+    skip_rows: int = 0,
     verbose: bool = False,
     fix_mojibake_sample: Optional[int] = None,
 ) -> int:
@@ -48,7 +49,9 @@ def process_csv(
         force: If True, overwrite existing output files (only when output_file is specified).
         keep_names: If True, keep original column names.
         delimiter: Output field delimiter.
+        skip_rows: Number of rows to skip at the beginning of the file.
         verbose: If True, enable debug logging.
+        fix_mojibake_sample: Sample size for mojibake detection, None to disable.
 
     Returns:
         Exit code: 0 for success, 1 for error.
@@ -249,7 +252,7 @@ def process_csv(
 
             try:
                 reject_count, error_types, fallback_config = validate_csv(
-                    working_file, reject_file, is_remote=is_remote
+                    working_file, reject_file, is_remote=is_remote, skip_rows=skip_rows
                 )
             except Exception as e:
                 progress.stop()
@@ -302,6 +305,7 @@ def process_csv(
                 delimiter=delimiter,
                 normalize_names=not keep_names,
                 is_remote=is_remote,
+                skip_rows=skip_rows,
                 fallback_config=fallback_config,
                 reject_file=reject_file,
             )

--- a/test/metadata_skip_rows.csv
+++ b/test/metadata_skip_rows.csv
@@ -1,0 +1,6 @@
+# Dataset: Sample Employee Data
+# Generated: 2026-01-17
+Employee Name,Department,Salary
+John Doe,Engineering,75000
+Jane Smith,Marketing,65000
+Bob Johnson,Sales,70000

--- a/test/title_row_skip.csv
+++ b/test/title_row_skip.csv
@@ -1,0 +1,5 @@
+Annual Sales Report 2025
+Product,Q1,Q2,Q3,Q4
+Widget A,100,120,130,150
+Widget B,200,210,220,240
+Widget C,150,160,170,180


### PR DESCRIPTION
Implements the --skip-rows (-s) CLI option to skip the first N rows
of CSV input files. This is useful for handling:
- Files with metadata/comments before the actual header
- Files with title rows before the column headers
- Legacy CSV files with non-standard prefixes

Changes:
- Add --skip-rows argument to CLI (cli.py)
- Pass skip_rows parameter through processing pipeline (core.py)
- Implement skip logic in DuckDB queries (validation.py)
- Add comprehensive test coverage (5 new tests)
- Update README.md with documentation and examples
- Add test fixtures for skip-rows scenarios
- Fix DuckDB /dev/null locking issue (use COUNT(*) instead)

All existing tests pass (26/26).